### PR TITLE
Edits to utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -825,7 +825,8 @@ def preprocess(checkpoint: bool, pdbdir: str, targetdir: str,alpha: float,
             os.mkdir(f'{pdbdir}/original_pdbs/')
             
         for unclean in glob.glob(f'{pdbdir}*.pdb'):
-            get_info(os.path.basename(unclean), pdbdir) 
+            getme = pdbdir + os.path.basename(unclean)
+            get_info(getme) 
             clean(unclean)
 
         # get target pocket alpha sphere count for fpocket cutoff calculation

--- a/utils.py
+++ b/utils.py
@@ -101,10 +101,10 @@ def get_info(pdbpath: str) -> None:
         cofactors = 'NONE'
 
     # write out all info to file
-    if not os.path.exists(f'{directory}infofiles/'):
-        os.mkdir(f'{directory}infofiles/')
+    if not os.path.exists(f'{directory}/infofiles/'):
+        os.mkdir(f'{directory}/infofiles/')
 
-    outfile = f'{directory}infofiles/{structure[:-4]}.info'
+    outfile = f'{directory}/infofiles/{structure[:-4]}.info'
     with open(outfile, 'w') as out:
         out.write(f'{title}\n')
         out.write(f'{exp_info.strip()}\n')

--- a/utils.py
+++ b/utils.py
@@ -51,7 +51,7 @@ def get_info(pdbpath: str) -> None:
         returns None, writes info to file in pdb directory
     """
     
-    structure, directory = os.path.split(pdbpath)
+    directory, structure = os.path.split(pdbpath)
 
     # read file
     reader = [line for line in open(pdbpath).readlines()]


### PR DESCRIPTION
## Pull request type
Bug fix

## Description
* Code not running: `get_info()` was given two arguments when it can only take one
* File path formatting in `get_info()`: structure & directory variables were swapped, and some file paths were missing the trailing '/', causing issues with finding/generating files and directories.

## Changes
### Line 828: get_info() TypeError 

`get_info()` takes 1 input (a string of the full path to the protein to extract info from) but is given two, causing the error:

    TypeError: get_info() takes 1 positional argument but 2 were given
This can be resolved by replacing line 828 with:

    getme = pdbdir + os.path.basename(unclean)
    get_info(getme)
Note: during debugging, I found that the variable `unclean` is already just the name of the pdb file, but I kept the `os.path.basename()` to be safe.


### Line 54: `os.path.split(pdbpath)`
`os.path.split(path)` returns the head and tail of the path [in that order.](https://docs.python.org/3/library/os.path.html) The variables `structure` and `directory` should be swapped as shown so that they each contain the correct part of the file path:
    
    directory, structure = os.path.split(pdbpath)`
This prevents errors in line 108 from incorrectly written file paths:

    #pdbpath="/.../pdbdir/PDBID.pdb
    #in line 54, structure, directory = os.path.split(pdbpath)
    
    outfile = f'{directory}infofiles/{structure[:-4]}.info'
    with open(outfile, 'w') as out:

    FileNotFoundError: [Errno 2] No such file or directory: 'PDBID.pdbinfofiles//.../pd.info'

    

### Lines 104-7: `get_info()` directory formatting
The trailing '/' is included in the path for every instance where a similar `directory` variable is used, except for this one. The infofiles directory should be nested inside the pdb directory, or there will be a FileNotFound error. 

    #get_info() creates the directory /.../pdbdirinfofiles instead of /.../pdbdir/infofiles

    FileNotFoundError: [Errno 2] No such file or directory: '/.../pdbdir/infofiles/'

Since the `directory` variable is consistenly missing the trailing '/', I decided to manually add it in instead of calling `check_format()`:

    if not os.path.exists(f'{directory}/infofiles/'):
    os.mkdir(f'{directory}/infofiles/')

    outfile = f'{directory}/infofiles/{structure[:-4]}.info'